### PR TITLE
Bugfix: preg_replace(addcslashes("|$matchmod[0]|"

### DIFF
--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -113,7 +113,7 @@ class PlgContentLoadmodule extends JPlugin
 				$output = $this->_loadmod($module, $name, $stylemod);
 
 				// We should replace only first occurrence in order to allow positions with the same name to regenerate their content:
-				$article->text = preg_replace(addcslashes("|$matchmod[0]|", '()'), addcslashes($output, '\\$'), $article->text, 1);
+				$article->text = preg_replace('|'.preg_quote($matchmod[0]).'|', addcslashes($output, '\\$'), $article->text, 1);
 				$stylemod = $this->params->def('style', 'none');
 			}
 		}


### PR DESCRIPTION
The part of the title after "Bugfix: " is wrong it should be
------------------------
preg_replace('|'.preg_quote($matchmod[0]).'|'
-----------------------
Fixes line 166 of /plugins/content/loadmodule/loadmodule.php
See the discussion at https://issues.joomla.org/tracker/joomla-cms/21329 for more / full information.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

